### PR TITLE
fix typo in Sampson error calculation

### DIFF
--- a/one-point/one-point.cpp
+++ b/one-point/one-point.cpp
@@ -108,7 +108,7 @@ void CvOnePointEstimator::computeReprojError( const CvMat* m1, const CvMat* m2,
         double a = Ex1.at<double>(0) * Ex1.at<double>(0); 
         double b = Ex1.at<double>(1) * Ex1.at<double>(1); 
         double c = Etx2.at<double>(0) * Etx2.at<double>(0); 
-        double d = Etx2.at<double>(0) * Etx2.at<double>(0); 
+        double d = Etx2.at<double>(1) * Etx2.at<double>(1);
 
         error->data.fl[i] = x2tEx1 * x2tEx1 / (a + b + c + d); 
 


### PR DESCRIPTION
Sampson distance follows the form:
![Screenshot from 2019-11-04 16-46-37](https://user-images.githubusercontent.com/4775141/68108452-c2949880-ff22-11e9-9f29-eceff59ad5cb.png)
